### PR TITLE
Release v0.6.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos, windows]
-        args: ["", "--no-default-features"]
+        args: ["", "--features=zeroize"]
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: setup environment
@@ -30,7 +30,7 @@ jobs:
           name: pass-${{ matrix.os }}${{ matrix.args }}
           path: target/debug/examples/pass${{ env.suffix }}
       - run: cargo test ${{ matrix.args }}
-        if: matrix.args == ''
+        if: matrix.args == '--features=zeroize'
 
   lint:
     name: cargo fmt && cargo clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "readpassphrase-3"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 description = "Simple wrapper around readpassphrase(3)"
 readme = "README.md"
 repository = "https://github.com/mrdomino/readpassphrase-3"
 license = "BSD-1-Clause"
-keywords = ["tty", "passphrase", "password"]
+keywords = ["getpass", "passphrase", "password", "tty"]
 categories = ["command-line-interface"]
 
 exclude = [
@@ -18,12 +18,15 @@ exclude = [
 [package.metadata.docs.rs]
 features = ["zeroize"]
 
+[features]
+default = ["cc"]
+
 [dependencies]
 bitflags = "2"
 zeroize = { version = "1", optional = true }
 
 [build-dependencies]
-cc = "1"
+cc = { version = "1", optional = true }
 
 [dev-dependencies]
 zeroize = "1"

--- a/README.md
+++ b/README.md
@@ -1,22 +1,23 @@
 # readpassphrase-3
+This crate endeavors to expose a thin Rust wrapper around the C [`readpassphrase(3)`][0] function for reading passphrases on the console in CLI programs.
 
-This crate endeavors to expose a thin Rust wrapper around the OpenBSD [`readpassphrase(3)`][0] function. Three interfaces are exposed:
-1. `getpass`, which allocates and returns its own fixed-size buffer for the passphrase;
-2. `readpassphrase`, which takes a buffer as a byte slice and returns a `&str` in that buffer; and
-3. `readpassphrase_owned`, which takes a preallocated buffer that it consumes and returns as the output `String`.
+This library uses a few third-party dependencies: flags to `readpassphrase` are implemented via the [bitflags][1] library, native builds are done via [cc][2], and memory zeroing can optionally be done by [zeroize][3]. To try to reduce churn in this library itself, we do not lock the versions of these dependencies; it is recommended that you vet their current versions yourself for compromises or software supply chain attacks. If you would rather not do that (or if you need support for wasm), consider instead using the excellent [rpassword][4] crate, which ships without external dependencies.
 
-These may be customized using `RppFlags`, which expose the original API’s flags.
+# Usage
+Add this crate to your project with `cargo add readpassphrase-3`. If you would like memory zeroing to be done by [zeroize][3], then you can instead say: `cargo add readpassphrase-3 -F zeroize`.
 
-This library uses a couple of third-party dependencies: `RppFlags` is implemented via the [bitflags][1] library, and memory zeroing is by default done via [zeroize][3]. To try to reduce churn in this library itself, and dependencies on multiple versions of libraries in dependent packages, we do not lock the versions of these dependencies; it is recommended that you vet their current versions yourself to guard against software supply chain attacks. If you would rather not do that, consider instead using the excellent [rpassword][4] crate, which vendors its own dependencies (and supports Windows!)
+See <https://docs.rs/readpassphrase-3> for documentation and examples.
+
+# Features
+- `cc`, enabled by default, compiles and uses a vendored version of the `readpassphrase` C function. (You may wish to turn this off to use the version from your system’s libc, or to compile and link the C function through other means.)
+- `zeroize` uses [zeroize][3] to zero memory internally (otherwise a minimal in-crate version is used.)
 
 # NFAQ
 
 ## I’m getting a “mismatched types” error!
-
 That’s not a question, but it’s okay. You are probably passing a Rust `&str` as the prompt argument. To avoid needing to take a dynamically allocated string or make a copy of the prompt on every call, this library takes a [`&CStr`][5] (i.e. a null-terminated span of characters) as its prompt argument.
 
 If you’re passing a literal string, you can just prepend `c` to your string:
-
 ```rust
 let _ = getpass(c"Prompt: ")?;
 //              ^
@@ -25,12 +26,11 @@ let _ = getpass(c"Prompt: ")?;
 ```
 
 ## Why is this named `readpassphrase-3`?
-
 There is already an unmaintained [readpassphrase][6] crate that was not to my liking. Rather than try to invent a new name for this standard C function, I decided to pick a number. The number I picked, 3, corresponds to the [“library calls” man section][7], in which readpassphrase’s man page is located.
 
 [0]: https://man.openbsd.org/readpassphrase
 [1]: https://crates.io/crates/bitflags
-[2]: https://docs.rs/thiserror/latest/thiserror/
+[2]: https://crates.io/crates/cc
 [3]: https://crates.io/crates/zeroize
 [4]: https://crates.io/crates/rpassword
 [5]: https://doc.rust-lang.org/std/ffi/struct.CStr.html

--- a/build.rs
+++ b/build.rs
@@ -6,20 +6,20 @@
 // The readpassphrase source and header are copyright 2000-2002, 2007, 2010
 // Todd C. Miller.
 
-use std::env;
-
 fn main() {
-    if env::var_os("CARGO_CFG_WINDOWS").is_some() {
-        cc::Build::new()
-            .file("csrc/read-password-w32.c")
-            .compile("readpassphrase");
-        println!("cargo:rerun-if-changed=csrc/read-password-w32.c");
-    } else {
-        cc::Build::new()
-            .file("csrc/readpassphrase.c")
-            .include("csrc")
-            .compile("readpassphrase");
-        println!("cargo:rerun-if-changed=csrc/readpassphrase.c");
-        println!("cargo:rerun-if-changed=csrc/readpassphrase.h");
+    #[cfg(feature = "cc")]
+    {
+        use std::env;
+
+        if env::var_os("CARGO_CFG_WINDOWS").is_some() {
+            cc::Build::new()
+                .file("csrc/read-password-w32.c")
+                .compile("read-password-w32");
+        } else {
+            cc::Build::new()
+                .file("csrc/readpassphrase.c")
+                .include("csrc")
+                .compile("readpassphrase");
+        }
     }
 }

--- a/csrc/read-password-w32.c
+++ b/csrc/read-password-w32.c
@@ -1,7 +1,5 @@
 /* Author: Chris Wellons
  * <https://nullprogram.com/blog/2020/05/04>
- *
- * This file is in the public domain.
  */
 
 /* UTF-8 console password prompt for Windows

--- a/examples/inplace.rs
+++ b/examples/inplace.rs
@@ -7,14 +7,10 @@
 // Todd C. Miller.
 
 use readpassphrase_3::{RppFlags, readpassphrase};
-#[cfg(feature = "zeroize")]
 use zeroize::Zeroizing;
 
 fn main() {
-    #[allow(unused_mut)]
-    let mut buf = vec![0u8; 256];
-    #[cfg(feature = "zeroize")]
-    let mut buf = Zeroizing::new(buf);
+    let mut buf = Zeroizing::new(vec![0u8; 256]);
     let password = readpassphrase(
         c"Password: ",
         &mut buf,

--- a/examples/owned.rs
+++ b/examples/owned.rs
@@ -7,19 +7,21 @@
 // Todd C. Miller.
 
 use readpassphrase_3::{Error, PASSWORD_LEN, RppFlags, readpassphrase, readpassphrase_owned};
+use zeroize::{Zeroize, Zeroizing};
 
 fn main() -> Result<(), Error> {
     let mut buf = vec![0u8; PASSWORD_LEN];
-    let pass = readpassphrase(c"Password: ", &mut buf, RppFlags::ECHO_ON)?.to_string();
+    let pass =
+        Zeroizing::new(readpassphrase(c"Password: ", &mut buf, RppFlags::ECHO_ON)?.to_string());
     let mut buf = Some(buf);
     loop {
-        let res = readpassphrase_owned(
+        let mut res = readpassphrase_owned(
             c"Confirmation: ",
             buf.take().unwrap(),
             RppFlags::REQUIRE_TTY,
-        )
-        .map_err(|(e, _)| e)?;
+        )?;
         if *pass == res {
+            res.zeroize();
             break;
         }
         buf = Some(res.into());

--- a/examples/pass.rs
+++ b/examples/pass.rs
@@ -6,9 +6,10 @@
 // The readpassphrase source and header are copyright 2000-2002, 2007, 2010
 // Todd C. Miller.
 
-use readpassphrase_3::getpass;
+use readpassphrase_3::{getpass, zeroize::Zeroize};
 
 fn main() {
-    let password = getpass(c"Password: ").expect("failed reading password");
+    let mut password = getpass(c"Password: ").expect("failed reading password");
     println!("{password}");
+    password.zeroize();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,7 @@
 // OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 // IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//! This library endeavors to expose a thin wrapper around OpenBSD’s [`readpassphrase(3)`][0]
-//! function.
+//! This library endeavors to expose a thin wrapper around the C [`readpassphrase(3)`][0] function.
 //!
 //! Three different interfaces are exposed; for most purposes, you will want to use either
 //! [`getpass`] (for simple password entry) or [`readpassphrase`] (when you need flags from
@@ -30,65 +29,142 @@
 //! The [`readpassphrase_owned`] function is a bit more niche; it may be used when you need a
 //! [`String`] output but need to pass flags or control the buffer size (vs [`getpass`].)
 //!
+//! Sensitive data should be zeroed as soon as possible to avoid leaving it visible in the
+//! process’s address space.
+//!
+//! # Usage
+//! To read a passphrase from the console:
+//! ```no_run
+//! # use readpassphrase_3::{getpass, zeroize::Zeroize};
+//! let mut pass = getpass(c"password: ").unwrap();
+//! // do_something_with(&pass);
+//! pass.zeroize();
+//! ```
+//!
+//! To control the buffer size or (on non-Windows) flags:
+//! ```no_run
+//! # use readpassphrase_3::{RppFlags, readpassphrase};
+//! # let mut buf = vec![0u8; 1];
+//! let pass = readpassphrase(c"pass: ", &mut buf, RppFlags::ECHO_ON).unwrap();
+//! ```
+//!
+//! To do so while transferring ownership:
+//! ```no_run
+//! # use readpassphrase_3::{Error, RppFlags, readpassphrase_owned};
+//! # fn main() -> Result<(), Error> {
+//! # let buf = vec![0u8; 1];
+//! let pass = readpassphrase_owned(c"pass: ", buf, RppFlags::empty())?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! This crate works well with the [`zeroize`][1] crate; for example, [`zeroize::Zeroizing`][2] may
+//! be used to zero buffer contents regardless of a function’s control flow:
+//!
+//! ```no_run
+//! # use readpassphrase_3::{Error, PASSWORD_LEN, RppFlags, readpassphrase};
+//! use zeroize::Zeroizing;
+//! # fn main() -> Result<(), Error> {
+//! let mut buf = Zeroizing::new(vec![0u8; PASSWORD_LEN]);
+//! let pass = readpassphrase(c"pass: ", &mut buf, RppFlags::REQUIRE_TTY)?;
+//! // do_something_that_can_fail_with(pass)?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # “Mismatched types” errors
+//! The prompt strings in this API are references to [CStr], not [str]. This is because the
+//! underlying C function assumes that the prompt is a null-terminated string; were we to take
+//! `&str` instead of `&CStr`, we would need to make a copy of the prompt on every call.
+//!
+//! Most of the time, your prompts will be string literals; you can ask Rust to give you a `&CStr`
+//! literal by simply prepending `c` to the string:
+//! ```no_run
+//! # use readpassphrase_3::{Error, getpass};
+//! # fn main() -> Result<(), Error> {
+//! let _ = getpass(c"pass: ")?;
+//! //              ^
+//! //              |
+//! //              like this
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Windows Limitations
+//! The Windows implementation of `readpassphrase(3)` that we are using does not yet support UTF-8
+//! in prompts; they must be ASCII. It also does not yet support flags, and always behaves as
+//! though called with [`RppFlags::empty()`].
+//!
 //! [0]: https://man.openbsd.org/readpassphrase
+//! [1]: https://docs.rs/zeroize/latest/zeroize/
+//! [2]: https://docs.rs/zeroize/latest/zeroize/struct.Zeroizing.html
 
-use std::{
-    ffi::{CStr, FromBytesUntilNulError},
-    fmt::Display,
-    io, mem,
-    str::Utf8Error,
-};
+use std::{ffi::CStr, fmt::Display, io, mem, str::Utf8Error};
 
 use bitflags::bitflags;
+use zeroize::Zeroize;
 
+#[cfg(all(not(docsrs), feature = "zeroize"))]
+pub use zeroize;
+
+/// Size of buffer used in [`getpass`].
+///
+/// Because `readpassphrase(3)` null-terminates its string, the actual maximum password length for
+/// [`getpass`] is 255.
 pub const PASSWORD_LEN: usize = 256;
 
 bitflags! {
-    /// Flags for controlling readpassphrase
+    /// Flags for controlling readpassphrase.
+    ///
+    /// The default flag `ECHO_OFF` is not represented here because `bitflags` [recommends against
+    /// zero-bit flags][0]; it may be specified as either [`RppFlags::empty()`] or
+    /// [`RppFlags::default()`].
+    ///
+    /// Note that the Windows `readpassphrase(3)` implementation always acts like it has been
+    /// passed `ECHO_OFF`, i.e., the flags are ignored.
+    ///
+    /// [0]: https://docs.rs/bitflags/latest/bitflags/#zero-bit-flags
+    #[derive(Default)]
     pub struct RppFlags: i32 {
-        /// Turn off echo (default)
-        const ECHO_OFF    = 0x00;
-        /// Leave echo on
+        /// Leave echo on.
         const ECHO_ON     = 0x01;
-        /// Fail if there is no tty
+        /// Fail if there is no tty.
         const REQUIRE_TTY = 0x02;
-        /// Force input to lower case
+        /// Force input to lower case.
         const FORCELOWER  = 0x04;
-        /// Force input to upper case
+        /// Force input to upper case.
         const FORCEUPPER  = 0x08;
-        /// Strip the high bit from input
+        /// Strip the high bit from input.
         const SEVENBIT    = 0x10;
-        /// Read from stdin, not /dev/tty
+        /// Read from stdin, not `/dev/tty`.
         const STDIN       = 0x20;
     }
 }
 
-impl Default for RppFlags {
-    fn default() -> Self {
-        Self::ECHO_OFF
-    }
-}
-
-/// Errors that can occur in readpassphrase
+/// Errors that can occur in readpassphrase.
 #[derive(Debug)]
 pub enum Error {
-    /// `readpassphrase(3)` itself encountered an error
+    /// `readpassphrase(3)` itself encountered an error.
     Io(io::Error),
-    /// The entered password did not parse as UTF-8
+    /// The entered password was not UTF-8.
     Utf8(Utf8Error),
-    /// The buffer did not contain a null terminator
-    CStr(FromBytesUntilNulError),
 }
 
 /// Reads a passphrase using `readpassphrase(3)`.
+///
+/// This function tries to faithfully wrap `readpassphrase(3)` without overhead; the only
+/// additional work it does is:
+/// 1. It converts from a Rust byte slice to a C pointer/length pair going in.
+/// 2. It converts from a C `char *` to a Rust UTF-8 `&str` coming out.
+/// 3. It translates errors from `errno` (or string conversion) into [`Result`].
 ///
 /// This function reads a passphrase of up to `buf.len() - 1` bytes. If the entered passphrase is
 /// longer, it will be truncated.
 ///
 /// # Security
-/// The passed buffer might contain sensitive data, even if this function returns an error (for
-/// example, if the contents are not valid UTF-8.) It is often considered good practice to zero
-/// this memory after you’re done with it, for example by using [`zeroize`]:
+/// The passed buffer might contain sensitive data even if this function returns an error (for
+/// example, if the contents are not valid UTF-8.) Therefore it should be zeroed as soon as
+/// possible. This can be achieved, for example, with [`zeroize::Zeroizing`][0]:
 /// ```no_run
 /// # use readpassphrase_3::{PASSWORD_LEN, Error, RppFlags, readpassphrase};
 /// use zeroize::Zeroizing;
@@ -98,6 +174,8 @@ pub enum Error {
 /// # Ok(())
 /// # }
 /// ```
+///
+/// [0]: https://docs.rs/zeroize/latest/zeroize/struct.Zeroizing.html
 pub fn readpassphrase<'a>(
     prompt: &CStr,
     buf: &'a mut [u8],
@@ -114,7 +192,7 @@ pub fn readpassphrase<'a>(
             return Err(io::Error::last_os_error().into());
         }
     }
-    Ok(CStr::from_bytes_until_nul(buf)?.to_str()?)
+    Ok(CStr::from_bytes_until_nul(buf).unwrap().to_str()?)
 }
 
 /// Reads a passphrase using `readpassphrase(3)`, returning it as a [`String`].
@@ -123,30 +201,33 @@ pub fn readpassphrase<'a>(
 /// `PASSWORD_LEN - 1` characters (accounting for the C null terminator.) If the entered passphrase
 /// is longer, it will be truncated.
 ///
-/// The passed flags are always the defaults, i.e., [`RppFlags::ECHO_OFF`].
+/// The passed flags are always [`RppFlags::default()`], i.e. `ECHO_OFF`.
 ///
 /// # Security
 /// The returned `String` is owned by the caller, and therefore it is the caller’s responsibility
-/// to clear it when you are done with it, for example by using [`zeroize`]:
+/// to clear it when you are done with it:
 /// ```no_run
-/// # use readpassphrase_3::{Error, getpass};
-/// use zeroize::Zeroizing;
+/// # use readpassphrase_3::{Error, getpass, zeroize::Zeroize};
 /// # fn main() -> Result<(), Error> {
-/// let pass = Zeroizing::new(getpass(c"Pass: ")?);
+/// let mut pass = getpass(c"Pass: ")?;
+/// _ = pass;
+/// pass.zeroize();
 /// # Ok(())
 /// # }
 /// ```
 pub fn getpass(prompt: &CStr) -> Result<String, Error> {
-    #[allow(unused_mut, unused_variables)]
-    readpassphrase_owned(prompt, vec![0u8; PASSWORD_LEN], RppFlags::empty()).map_err(
-        |(e, mut buf)| {
-            explicit_bzero(&mut buf);
-            e
-        },
-    )
+    Ok(readpassphrase_owned(
+        prompt,
+        vec![0u8; PASSWORD_LEN],
+        RppFlags::empty(),
+    )?)
 }
 
-/// Reads a passphrase using `readpassphrase(3)` using the passed buffer’s memory.
+/// An error from [`readpassphrase_owned`]. Contains the passed buffer.
+#[derive(Debug)]
+pub struct OwnedError(Error, Option<Vec<u8>>);
+
+/// Reads a passphrase using `readpassphrase(3)` by reusing the passed buffer’s memory.
 ///
 /// This function reads a passphrase of up to `buf.capacity() - 1` bytes. If the entered passphrase
 /// is longer, it will be truncated.
@@ -161,14 +242,18 @@ pub fn getpass(prompt: &CStr) -> Result<String, Error> {
 ///
 /// This can be done via [`zeroize`], e.g.:
 /// ```no_run
-/// # use readpassphrase_3::{PASSWORD_LEN, Error, RppFlags, readpassphrase_owned};
-/// use zeroize::{Zeroizing, Zeroize};
+/// # use readpassphrase_3::{
+/// #     PASSWORD_LEN,
+/// #     Error,
+/// #     RppFlags,
+/// #     readpassphrase_owned,
+/// #     zeroize::Zeroize,
+/// # };
 /// # fn main() -> Result<(), Error> {
 /// let buf = vec![0u8; PASSWORD_LEN];
-/// let pass = Zeroizing::new(
-///     readpassphrase_owned(c"Pass: ", buf, RppFlags::default())
-///         .map_err(|(e, mut buf)| { buf.zeroize(); e })?
-/// );
+/// let mut pass = readpassphrase_owned(c"Pass: ", buf, RppFlags::default())?;
+/// _ = pass;
+/// pass.zeroize();
 /// # Ok(())
 /// # }
 /// ```
@@ -176,17 +261,17 @@ pub fn readpassphrase_owned(
     prompt: &CStr,
     mut buf: Vec<u8>,
     flags: RppFlags,
-) -> Result<String, (Error, Vec<u8>)> {
+) -> Result<String, OwnedError> {
     readpassphrase_mut(prompt, &mut buf, flags).map_err(|e| {
         buf.clear();
-        (e, buf)
+        OwnedError(e, Some(buf))
     })
 }
 
-/// Reads a passphrase into `buf`’s maybe-uninitialized capacity and returns it as a `String`
-/// reusing `buf`’s memory on success. This function serves to make it possible to write
-/// `readpassphrase_owned` without either pre-initializing the buffer or invoking undefined
-/// behavior by constructing a maybe-uninitialized slice.
+// Reads a passphrase into `buf`’s maybe-uninitialized capacity and returns it as a `String`
+// reusing `buf`’s memory on success. This function serves to make it possible to write
+// `readpassphrase_owned` without either pre-initializing the buffer or invoking undefined
+// behavior by constructing a maybe-uninitialized slice.
 fn readpassphrase_mut(prompt: &CStr, buf: &mut Vec<u8>, flags: RppFlags) -> Result<String, Error> {
     unsafe {
         let res = ffi::readpassphrase(
@@ -206,29 +291,42 @@ fn readpassphrase_mut(prompt: &CStr, buf: &mut Vec<u8>, flags: RppFlags) -> Resu
 
 /// Securely zero the memory in `buf`.
 ///
-/// This function clears the full capacity of `buf` by writing zeroes to it, thereby erasing any
-/// sensitive data in `buf`. It should be called to clear any sensitive passphrases once they are
-/// no longer in use.
+/// This function zeroes the full capacity of `buf`, erasing any sensitive data in it. It is
+/// a simple shim for [`zeroize`] and the latter should be used instead.
 ///
-/// If the `zeroize` feature is enabled, this internally uses [`zeroize::Zeroize`].
+/// # Usage
+/// The following are equivalent:
+/// ```no_run
+/// # use readpassphrase_3::{explicit_bzero, zeroize::Zeroize};
+/// let mut buf = vec![1u8; 1];
+/// // 1.
+/// explicit_bzero(&mut buf);
+/// // 2.
+/// buf.zeroize();
+/// ```
+#[deprecated(since = "0.6.0", note = "use zeroize::Zeroize instead")]
 pub fn explicit_bzero(buf: &mut Vec<u8>) {
-    #[cfg(feature = "zeroize")]
-    {
-        use zeroize::Zeroize;
-        buf.zeroize();
+    buf.zeroize();
+}
+
+impl OwnedError {
+    /// Take `buf` out of the error.
+    ///
+    /// Returns empty [`Vec`] after the first call.
+    pub fn take(&mut self) -> Vec<u8> {
+        self.1.take().unwrap_or_default()
     }
-    #[cfg(not(feature = "zeroize"))]
-    {
-        buf.clear();
-        buf.spare_capacity_mut()
-            .fill(std::mem::MaybeUninit::zeroed());
-        unsafe {
-            core::arch::asm!(
-                "/* {ptr} */",
-                ptr = in(reg) buf.as_ptr(),
-                options(nostack, readonly, preserves_flags),
-            );
-        }
+}
+
+impl Drop for OwnedError {
+    fn drop(&mut self) {
+        self.1.take().as_mut().map(zeroize::Zeroize::zeroize);
+    }
+}
+
+impl From<OwnedError> for Error {
+    fn from(mut value: OwnedError) -> Self {
+        mem::replace(&mut value.0, Error::Io(io::ErrorKind::Other.into()))
     }
 }
 
@@ -244,9 +342,15 @@ impl From<Utf8Error> for Error {
     }
 }
 
-impl From<FromBytesUntilNulError> for Error {
-    fn from(value: FromBytesUntilNulError) -> Self {
-        Error::CStr(value)
+impl core::error::Error for OwnedError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+impl Display for OwnedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 
@@ -255,7 +359,6 @@ impl core::error::Error for Error {
         match self {
             Error::Io(e) => Some(e),
             Error::Utf8(e) => Some(e),
-            Error::CStr(e) => Some(e),
         }
     }
 }
@@ -265,7 +368,56 @@ impl Display for Error {
         match self {
             Error::Io(e) => e.fmt(f),
             Error::Utf8(e) => e.fmt(f),
-            Error::CStr(e) => e.fmt(f),
+        }
+    }
+}
+
+/// A minimal in-crate implementation of [`zeroize::Zeroize`][0].
+///
+/// This provides compile-fenced memory zeroing for [`String`]s and [`Vec`]s without needing to
+/// depend on the `zeroize` crate.
+///
+/// If the optional `zeroize` feature is enabled, then this module is replaced with `zeroize`
+/// itself.
+///
+/// [0]: https://docs.rs/zeroize/latest/zeroize/trait.Zeroize.html
+#[cfg(any(docsrs, not(feature = "zeroize")))]
+pub mod zeroize {
+    use std::{arch::asm, mem::MaybeUninit};
+
+    /// Trait for securely erasing values from memory.
+    pub trait Zeroize {
+        fn zeroize(&mut self);
+    }
+
+    impl Zeroize for Vec<u8> {
+        fn zeroize(&mut self) {
+            self.clear();
+            self.spare_capacity_mut().fill(MaybeUninit::zeroed());
+            compile_fence(self);
+        }
+    }
+
+    impl Zeroize for String {
+        fn zeroize(&mut self) {
+            unsafe { self.as_mut_vec() }.zeroize();
+        }
+    }
+
+    impl Zeroize for [u8] {
+        fn zeroize(&mut self) {
+            self.fill(0);
+            compile_fence(self);
+        }
+    }
+
+    fn compile_fence(buf: &[u8]) {
+        unsafe {
+            asm!(
+                "/* {ptr} */",
+                ptr = in(reg) buf.as_ptr(),
+                options(nostack, preserves_flags, readonly)
+            );
         }
     }
 }


### PR DESCRIPTION
This change includes substantial documentation improvements and some new APIs and cleanup work.

# Breaking changes
* The `zeroize` feature is no longer enabled by default. If it is disbled, this crate includes its own minimal implementation of `zeroize::Zeroize` that can zero the specific types relevant to this library (i.e., `Vec<u8>`, `String`, and `[u8]`.) This is exposed as `mod zeroize`; now, the `zeroize` feature simply swaps this out for [`zeroize::Zeroize`][0].
* I removed the CStr error fork since `FromBytesUntilNulError` cannot happen as long as `readpassphrase(3)` keeps its contract, which we already assume elsewhere. Now the user-facing `Error` is much simpler: either `readpassphrase(3)` itself encountered an IO error or we encountered non–UTF-8 data.
* I changed `readpassphrase_owned` to return a new `OnwedError` type that includes the buffer on it and zeroizes that buffer on drop. `Error` now implements `From<OwnedError>`, making this easy to use with the `?` operator.
* The `explicit_bzero` function introduced before has been deprecated in favor of using either this new trait or `zeroize` itself, and generally the crate now encourages using `zeroize` a bit more.

# README cleanup
I removed the mention of OpenBSD from the readme since it might give the impression that this crate was BSD-only or something. The man link to openbsd.org remains.

I also removed usage instructions from the readme, locating them instead on [docs.rs](https://docs.rs) by way of the doc comment in `src/lib.rs`.

I added `getpass` to the keywords for this library.

# Optional `cc` feature
Now it is possible to disable `cc`, which stops the C `readpassphrase` code from being compiled. This allows either foreign C builds (e.g. via Bazel) or use of the system libc’s built-in `readpassphrase` on platforms that have it.

# docs.rs build tweaks
The build for <https://docs.rs> now turns on the `zeroize` feature in the hopes that this will allow the examples to compile, but specifically includes the minimal `zeroize` shim rather than the re-export of the `zeroize` crate module.

Alongside this, the examples now use `zeroize` again.

[0]: https://crates.io/crates/zeroize