### PR TITLE
Release v0.8.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,6 @@ jobs:
           name: pass-${{ matrix.os }}${{ matrix.args }}
           path: target/debug/examples/pass${{ env.suffix }}
       - run: cargo test ${{ matrix.args }}
-        if: matrix.args == '--features=zeroize'
 
   lint:
     name: cargo fmt && cargo clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "readpassphrase-3"
-version = "0.8.0-pre.3"
+version = "0.8.0-pre.4"
 edition = "2024"
 rust-version = "1.85.1"
 description = "Simple wrapper around readpassphrase(3)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "readpassphrase-3"
-version = "0.7.1"
+version = "0.8.0-pre.0"
 edition = "2024"
 rust-version = "1.85.1"
 description = "Simple wrapper around readpassphrase(3)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "readpassphrase-3"
-version = "0.8.0-pre.2"
+version = "0.8.0-pre.3"
 edition = "2024"
 rust-version = "1.85.1"
 description = "Simple wrapper around readpassphrase(3)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "readpassphrase-3"
-version = "0.8.0-pre.1"
+version = "0.8.0-pre.2"
 edition = "2024"
 rust-version = "1.85.1"
 description = "Simple wrapper around readpassphrase(3)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "readpassphrase-3"
-version = "0.8.0-pre.0"
+version = "0.8.0-pre.1"
 edition = "2024"
 rust-version = "1.85.1"
 description = "Simple wrapper around readpassphrase(3)"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # readpassphrase-3
 This crate endeavors to expose a thin Rust wrapper around the C [`readpassphrase(3)`][0] function for reading passphrases on the console in CLI programs.
 
-This library uses a few third-party dependencies: flags to `readpassphrase` are implemented via the [`bitflags`][1] library, native builds are done via [`cc`][2], and memory zeroing can optionally be done by [`zeroize`][3]. To try to reduce churn in this library itself, we do not lock the versions of these dependencies; it is recommended that you vet their current versions yourself for compromises or software supply chain attacks. If you would rather not do that (or if you need support for wasm), consider instead using the excellent [`rpassword`][4] crate, which ships without external dependencies.
+It uses a few third-party dependencies: flags to `readpassphrase` are implemented via the [`bitflags`][1] library, native builds are done via [`cc`][2], and memory zeroing can optionally be done by [`zeroize`][3]. To try to reduce churn in this library itself, we do not lock the versions of these dependencies; it is recommended that you vet their current versions yourself for compromises or software supply chain attacks. If you would rather not do that (or if you need support for wasm), consider instead using the excellent [`rpassword`][4] crate, which ships without external dependencies.
 
 # Usage
 Add this crate to your project:

--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ let _ = getpass(c"Prompt: ")?;
 //              like this
 ```
 
+If you need a dynamic prompt, look at [`CString`][6].
+
 ## Why is this named `readpassphrase-3`?
-There is already an unmaintained [`readpassphrase`][6] crate that was not to my liking. Rather than try to invent a new name for this standard C function, I decided to pick a number. The number I picked, 3, corresponds to the [“library calls” man section][7], in which readpassphrase’s man page is located.
+There is already an unmaintained [`readpassphrase`][7] crate that was not to my liking. Rather than try to invent a new name for this standard C function, I decided to pick a number. The number I picked, 3, corresponds to the [“library calls” man section][8], in which readpassphrase’s man page is located.
 
 [0]: https://man.openbsd.org/readpassphrase
 [1]: https://crates.io/crates/bitflags
@@ -49,5 +51,6 @@ There is already an unmaintained [`readpassphrase`][6] crate that was not to my 
 [3]: https://crates.io/crates/zeroize
 [4]: https://crates.io/crates/rpassword
 [5]: https://doc.rust-lang.org/std/ffi/struct.CStr.html
-[6]: https://crates.io/crates/readpassphrase
-[7]: https://man7.org/linux/man-pages/man7/man-pages.7.html
+[6]: https://doc.rust-lang.org/std/ffi/struct.CString.html
+[7]: https://crates.io/crates/readpassphrase
+[8]: https://man7.org/linux/man-pages/man7/man-pages.7.html

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ See <https://docs.rs/readpassphrase-3> for documentation and examples.
 
 # NFAQ
 
+## Why use this?
+[`readpassphrase(3)`][0] is a standard function that exists in many platforms’ libc implementations. It has had a lot of miles put on it; it is well-tested and works even under conditions like suspend/resume with `C-z` / `fg`, keeping echo off and so forth.
+
+As well, `readpassphrase(3)` —and the interfaces this library exposes to it— does not allocate extra memory, making it relatively easy to be sure that you have zeroed all copies of your passwords after use. As long as you zero the memory you own, either the buffer you pass in to the non-owned `readpassphrase` or the `String` you receive from the owned `getpass`, you’re good.
+
+## Why not use this?
+This crate requires either a `readpassphrase(3)` in the libc on your target platform or a build-time dependency on a C compiler; if you do not wish to take that on, then you should look elsewhere.
+
 ## I’m getting a “mismatched types” error!
 That’s not a question, but it’s okay. You are probably passing a Rust `&str` as the prompt argument. To avoid needing to take a dynamically allocated string or make a copy of the prompt on every call, this library takes a [`&CStr`][5] (i.e. a null-terminated span of characters) as its prompt argument.
 

--- a/examples/inplace.rs
+++ b/examples/inplace.rs
@@ -8,18 +8,18 @@
 
 use std::process::exit;
 
-use readpassphrase_3::{PASSWORD_LEN, RppFlags, readpassphrase};
+use readpassphrase_3::{Flags, PASSWORD_LEN, readpassphrase};
 use zeroize::Zeroizing;
 
 fn main() {
     let mut buf = Zeroizing::new(vec![0u8; PASSWORD_LEN]);
     let password = Zeroizing::new(
-        readpassphrase(c"Password: ", &mut buf, RppFlags::empty())
+        readpassphrase(c"Password: ", &mut buf, Flags::empty())
             .expect("failed reading passphrase")
             .to_string(),
     );
     for _ in 0..5 {
-        let confirm = readpassphrase(c"Confirmation: ", &mut buf, RppFlags::REQUIRE_TTY)
+        let confirm = readpassphrase(c"Confirmation: ", &mut buf, Flags::REQUIRE_TTY)
             .expect("failed reading confirmation");
         if *password == confirm {
             eprintln!("Passwords match.");

--- a/examples/inplace.rs
+++ b/examples/inplace.rs
@@ -8,18 +8,18 @@
 
 use std::process::exit;
 
-use readpassphrase_3::{Flags, PASSWORD_LEN, readpassphrase};
+use readpassphrase_3::{Flags as RpFlags, PASSWORD_LEN, readpassphrase};
 use zeroize::Zeroizing;
 
 fn main() {
     let mut buf = Zeroizing::new(vec![0u8; PASSWORD_LEN]);
     let password = Zeroizing::new(
-        readpassphrase(c"Password: ", &mut buf, Flags::empty())
+        readpassphrase(c"Password: ", &mut buf, RpFlags::empty())
             .expect("failed reading passphrase")
             .to_string(),
     );
     for _ in 0..5 {
-        let confirm = readpassphrase(c"Confirmation: ", &mut buf, Flags::REQUIRE_TTY)
+        let confirm = readpassphrase(c"Confirmation: ", &mut buf, RpFlags::REQUIRE_TTY)
             .expect("failed reading confirmation");
         if *password == confirm {
             eprintln!("Passwords match.");

--- a/examples/owned.rs
+++ b/examples/owned.rs
@@ -6,20 +6,16 @@
 // The readpassphrase source and header are copyright 2000-2002, 2007, 2010
 // Todd C. Miller.
 
-use readpassphrase_3::{Error, PASSWORD_LEN, RppFlags, readpassphrase, readpassphrase_owned};
+use readpassphrase_3::{Error, Flags, PASSWORD_LEN, readpassphrase, readpassphrase_owned};
 use zeroize::{Zeroize, Zeroizing};
 
 fn main() -> Result<(), Error> {
     let mut buf = vec![0u8; PASSWORD_LEN];
-    let pass =
-        Zeroizing::new(readpassphrase(c"Password: ", &mut buf, RppFlags::ECHO_ON)?.to_string());
+    let pass = Zeroizing::new(readpassphrase(c"Password: ", &mut buf, Flags::ECHO_ON)?.to_string());
     let mut buf = Some(buf);
     loop {
-        let mut res = readpassphrase_owned(
-            c"Confirmation: ",
-            buf.take().unwrap(),
-            RppFlags::REQUIRE_TTY,
-        )?;
+        let mut res =
+            readpassphrase_owned(c"Confirmation: ", buf.take().unwrap(), Flags::REQUIRE_TTY)?;
         if *pass == res {
             res.zeroize();
             break;

--- a/examples/owned.rs
+++ b/examples/owned.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Error> {
             res.zeroize();
             break;
         }
-        buf = Some(res.into());
+        buf = Some(res.into_bytes());
     }
     Ok(())
 }

--- a/examples/owned.rs
+++ b/examples/owned.rs
@@ -10,9 +10,11 @@ use readpassphrase_3::{Error, Flags, PASSWORD_LEN, readpassphrase, readpassphras
 use zeroize::{Zeroize, Zeroizing};
 
 fn main() -> Result<(), Error> {
-    let mut buf = vec![0u8; PASSWORD_LEN];
-    let pass = Zeroizing::new(readpassphrase(c"Password: ", &mut buf, Flags::ECHO_ON)?.to_string());
-    let mut buf = Some(buf);
+    let mut buf = Zeroizing::new(Some(vec![0u8; PASSWORD_LEN]));
+    let pass = Zeroizing::new(
+        readpassphrase(c"Password: ", buf.as_deref_mut().unwrap(), Flags::ECHO_ON)?.to_string(),
+    );
+    let mut buf = buf.take();
     loop {
         let mut res =
             readpassphrase_owned(c"Confirmation: ", buf.take().unwrap(), Flags::REQUIRE_TTY)?;

--- a/examples/pass.rs
+++ b/examples/pass.rs
@@ -6,7 +6,7 @@
 // The readpassphrase source and header are copyright 2000-2002, 2007, 2010
 // Todd C. Miller.
 
-use readpassphrase_3::{getpass, zeroize::Zeroize};
+use readpassphrase_3::{Zeroize, getpass};
 
 fn main() {
     let mut password = getpass(c"Password: ").expect("failed reading password");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,7 @@ pub fn getpass(prompt: &CStr) -> Result<String, Error> {
 #[derive(Debug)]
 pub struct OwnedError(Error, Option<Vec<u8>>);
 
-/// Reads a passphrase using `readpassphrase(3)`, returning a [`String`] reusing `buf`’s memory.
+/// Reads a passphrase using `readpassphrase(3)`, returning `buf` as a [`String`].
 ///
 /// This function reads a passphrase of up to `buf.capacity() - 1` bytes. If the entered passphrase
 /// is longer, it will be truncated.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //! # Security
 //! Sensitive data should be zeroed as soon as possible to avoid leaving it visible in the
 //! process’s address space. It is your job to ensure that this is done with the data you own, i.e.
-//! any [`Vec`] buffer passed to [`readpassphrase`] or any [`String`] received from [`getpass`] or
+//! any [`Vec`] passed to [`readpassphrase`] or any [`String`] received from [`getpass`] or
 //! [`readpassphrase_owned`].
 //!
 //! This crate ships with a minimal [`Zeroize`] trait that may be used for this purpose:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,8 @@
 //! If you need to pass [`Flags`] or to control the buffer size, then you can use
 //! [`readpassphrase`] or [`readpassphrase_owned`] depending on your ownership requirements:
 //! ```no_run
-//! use readpassphrase_3::{Flags, readpassphrase};
 //! let mut buf = vec![0u8; 256];
+//! use readpassphrase_3::{Flags, readpassphrase};
 //! let pass: &str = readpassphrase(c"Password: ", &mut buf, Flags::default()).unwrap();
 //!
 //! use readpassphrase_3::readpassphrase_owned;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,10 +41,11 @@
 //! ```no_run
 //! use readpassphrase_3::{Flags, readpassphrase};
 //! let mut buf = vec![0u8; 256];
-//! let _ = readpassphrase(c"Password: ", &mut buf, Flags::default()).unwrap();
+//! let pass: &str = readpassphrase(c"Password: ", &mut buf, Flags::default()).unwrap();
 //!
 //! use readpassphrase_3::readpassphrase_owned;
-//! let _ = readpassphrase_owned(c"Pass: ", buf, Flags::FORCELOWER).unwrap();
+//! let pass: String = readpassphrase_owned(c"Pass: ", buf, Flags::FORCELOWER).unwrap();
+//! # _ = pass;
 //! ```
 //!
 //! # Security

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,8 +71,8 @@
 //! ```
 //!
 //! ## Zeroizing memory
-//! This crate works well with the [`zeroize`] crate. For example, [`zeroize::Zeroizing`] may be
-//! used to zero buffer contents regardless of a function’s control flow:
+//! This crate works well with the [`::zeroize`] crate. For example, [`::zeroize::Zeroizing`] may
+//! be used to zero buffer contents regardless of a function’s control flow:
 //! ```no_run
 //! # use readpassphrase_3::{Error, PASSWORD_LEN, RppFlags, getpass, readpassphrase};
 //! use zeroize::Zeroizing;
@@ -120,11 +120,11 @@
 
 use std::{ffi::CStr, fmt::Display, io, mem, str::Utf8Error};
 
+#[cfg(all(not(docsrs), feature = "zeroize"))]
+pub use ::zeroize::Zeroize;
 use bitflags::bitflags;
 #[cfg(any(docsrs, not(feature = "zeroize")))]
 pub use our_zeroize::Zeroize;
-#[cfg(all(not(docsrs), feature = "zeroize"))]
-pub use zeroize::Zeroize;
 
 /// Size of buffer used in [`getpass`].
 ///
@@ -178,7 +178,7 @@ pub enum Error {
 /// # Security
 /// The passed buffer might contain sensitive data, even if this function returns an error.
 /// Therefore it should be zeroed as soon as possible. This can be achieved, for example, with
-/// [`zeroize::Zeroizing`]:
+/// [`::zeroize::Zeroizing`]:
 /// ```no_run
 /// # use readpassphrase_3::{PASSWORD_LEN, Error, RppFlags, readpassphrase};
 /// use zeroize::Zeroizing;
@@ -412,6 +412,14 @@ mod our_zeroize {
             );
         }
     }
+}
+
+#[deprecated(
+    since = "0.8.0",
+    note = "use top-level Zeroize or crate zeroize instead"
+)]
+pub mod zeroize {
+    pub use crate::Zeroize;
 }
 
 mod ffi {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! let _ = getpass(c"Enter your password: ").expect("failed reading password");
 //! ```
 //!
-//! If you need to pass [`RppFlags`] or to control the buffer size, then you can use
+//! If you need to pass [flags](RppFlags) or to control the buffer size, then you can use
 //! [`readpassphrase`] or [`readpassphrase_owned`] depending on your ownership requirements:
 //! ```no_run
 //! use readpassphrase_3::{RppFlags, readpassphrase};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,8 @@
 //! # }
 //! ```
 //!
+//! If you need a dynamic prompt, look at [`CString`](std::ffi::CString).
+//!
 //! # Windows Limitations
 //! The Windows implementation of `readpassphrase(3)` that we are using does not yet support UTF-8
 //! in prompts; they must be ASCII. It also does not yet support flags, and always behaves as

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,12 @@
 
 //! Lightweight, easy-to-use wrapper around the C [`readpassphrase(3)`][0] function.
 //!
+//! From the man page:
+//! > The `readpassphrase()` function displays a prompt to, and reads in a passphrase from,
+//! > `/dev/tty`. If this file is inaccessible and the [`RPP_REQUIRE_TTY`](Flags::REQUIRE_TTY) flag
+//! > is not set, `readpassphrase()` displays the prompt on the standard error output and reads
+//! > from the standard input.
+//!
 //! # Usage
 //! For the simplest of cases, where you would just like to read a password from the console into a
 //! [`String`] to use elsewhere, you can use [`getpass`]:
@@ -42,8 +48,11 @@
 //! ```
 //!
 //! # Security
-//! Sensitive data should be zeroed as soon as possible to avoid leaving it visible in the
-//! process’s address space. It is your job to ensure that this is done with the data you own, i.e.
+//! The [`readpassphrase(3)` man page][0] says:
+//! > The calling process should zero the passphrase as soon as possible to avoid leaving the
+//! > cleartext passphrase visible in the process's address space.
+//!
+//! It is your job to ensure that this is done with the data you own, i.e.
 //! any [`Vec`] passed to [`readpassphrase`] or any [`String`] received from [`getpass`] or
 //! [`readpassphrase_owned`].
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,10 +240,10 @@ pub fn getpass(prompt: &CStr) -> Result<String, Error> {
     )?)
 }
 
-/// An error from [`readpassphrase_owned`].
+/// An [`Error`] from [`readpassphrase_owned`] containing the passed buffer.
 ///
-/// This wraps [`Error`] but also contains the passed buffer, accessible via [`OwnedError::take`].
-/// If [`take`](OwnedError::take) is not called, the buffer is automatically zeroed on drop.
+/// The buffer is accessible via [`OwnedError::take`]. If [`take`](OwnedError::take) is not called,
+/// the buffer is automatically zeroed on drop.
 #[derive(Debug)]
 pub struct OwnedError(Error, Option<Vec<u8>>);
 


### PR DESCRIPTION
# Breaking changes
- The deprecated `explicit_bzero` function has been removed.
- `RppFlags` has been renamed to just `Flags` with the former exposed as a deprecated alias.
- This crate’s `zeroize::Zeroize` has been moved to a top-level `Zeroize` trait and the `zeroize` module has been deprecated.

# Documentation cleanup
- The README has been expanded to explain why someone would want to use this crate.
- The doc comments have been proofread and clarified further, including a couple quotes from the `readpassphrase(3)` man page.
- `examples/owned.rs` now properly zeroes memory for the initial password.