### PR TITLE
Release v0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "readpassphrase-3"
-version = "0.8.0"
+version = "0.9.0-pre.0"
 edition = "2024"
 rust-version = "1.85.1"
 description = "Simple wrapper around readpassphrase(3)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "readpassphrase-3"
-version = "0.9.0-pre.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.85.1"
 description = "Simple wrapper around readpassphrase(3)"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,8 +76,8 @@
 //! ```
 //!
 //! ## Zeroizing memory
-//! This crate works well with the [`::zeroize`] crate. For example, [`::zeroize::Zeroizing`] may
-//! be used to zero buffer contents regardless of a function’s control flow:
+//! This crate works well with the [`zeroize`] crate. For example, [`zeroize::Zeroizing`] may be
+//! used to zero buffer contents regardless of a function’s control flow:
 //! ```no_run
 //! # use readpassphrase_3::{Error, Flags, PASSWORD_LEN, getpass, readpassphrase};
 //! use zeroize::Zeroizing;
@@ -125,11 +125,11 @@
 
 use std::{ffi::CStr, fmt::Display, io, mem, str::Utf8Error};
 
-#[cfg(all(not(docsrs), feature = "zeroize"))]
-pub use ::zeroize::Zeroize;
 use bitflags::bitflags;
 #[cfg(any(docsrs, not(feature = "zeroize")))]
 pub use our_zeroize::Zeroize;
+#[cfg(all(not(docsrs), feature = "zeroize"))]
+pub use zeroize::Zeroize;
 
 /// Size of buffer used in [`getpass`].
 ///
@@ -165,9 +165,6 @@ bitflags! {
     }
 }
 
-#[deprecated(since = "0.8.0", note = "Use Flags instead")]
-pub type RppFlags = Flags;
-
 /// Errors that can occur in readpassphrase.
 #[derive(Debug)]
 pub enum Error {
@@ -186,7 +183,7 @@ pub enum Error {
 /// # Security
 /// The passed buffer might contain sensitive data, even if this function returns an error.
 /// Therefore it should be zeroed as soon as possible. This can be achieved, for example, with
-/// [`::zeroize::Zeroizing`]:
+/// [`zeroize::Zeroizing`]:
 /// ```no_run
 /// # use readpassphrase_3::{PASSWORD_LEN, Error, Flags, readpassphrase};
 /// use zeroize::Zeroizing;
@@ -420,14 +417,6 @@ mod our_zeroize {
             );
         }
     }
-}
-
-#[deprecated(
-    since = "0.8.0",
-    note = "use top-level Zeroize or crate zeroize instead"
-)]
-pub mod zeroize {
-    pub use crate::Zeroize;
 }
 
 mod ffi {


### PR DESCRIPTION
# Breaking changes
- `zeroize::Zeroize`, made an alias to the top-level `Zeroize` introduced in v0.8, has been removed.
- `RppFlags`, made an alias to `Flags` in v0.8, has been removed.