### PR TITLE
Rename features, `libbsd` feature for pkg-config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,9 @@ name = "owned"
 path = "examples/owned.rs"
 
 [features]
-default = ["cc"]
+default = ["vendored"]
+libbsd = []
+vendored = ["dep:cc"]
 
 [dependencies]
 bitflags = "2"


### PR DESCRIPTION
The `cc` feature has been renamed to `vendored`, and a new `libbsd` feature has been added to turn on static linking against `libbsd`. The `libbsd` feature takes priority over `vendored`, i.e., if both are specified, then only `libbsd` will be used.