### PR TITLE
Replace debug assert with `&[MaybeUninit<u8>]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,10 +284,10 @@ pub fn readpassphrase_owned(
     })
 }
 
-// Reads a passphrase into `buf`’s maybe-uninitialized capacity and returns it as a `String`
-// reusing `buf`’s memory on success. This function serves to make it possible to write
-// `readpassphrase_owned` without either pre-initializing the buffer or invoking undefined
-// behavior by constructing a maybe-uninitialized slice.
+// Reads a passphrase into `buf`’s full capacity and returns it as a `String` reusing `buf`’s
+// memory on success. This function serves to make it possible to write `readpassphrase_owned`
+// without either pre-initializing the buffer or invoking undefined behavior by constructing a
+// potentially uninitialized slice.
 fn readpassphrase_mut(prompt: &CStr, buf: &mut Vec<u8>, flags: Flags) -> Result<String, Error> {
     // If we could construct a `&[u8]` out of potentially uninitialized memory, then this whole
     // function could just be:


### PR DESCRIPTION
This reworks `readpassphrase_mut` so that it directly finds the null byte instead of calling into `CStr` to do so, achieving the same guarantees as the prior `debug_assert` but without the extra pass through `buf`. We avoid UB on the constructed slice via the simple expedient of constructing a `&[MaybeUninit<u8>]` instead of a `&[u8]`.

We still require `readpassphrase(3)` to have initialized its memory, either by initializing the full buffer width (in which case we will panic if there is not a null byte) or by writing a null byte within its initialized memory. If an implementation does not do this, e.g. if it does not touch `buf` at all but returns a non-null pointer, then UB will result. This is the compromise we make in order to not need to fully initialize `buf`’s allocation before calling `ffi::readpassphrase`.