### PR TITLE
feat: Optionally use libbsd-sys crate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,11 @@ jobs:
         if: ${{ matrix.os != 'windows' && matrix.os != 'ubuntu' }}
 
       - run: cargo test --all-targets
+
       - run: cargo test --all-targets --all-features
+        # "All features" builds pull in libbsd-sys, which fails on ubuntu if
+        # libbsd-dev is not installed.
+        if: ${{ matrix.libbsd || matrix.os != 'ubuntu' }}
 
   lint:
     name: cargo fmt && cargo clippy

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
         toolchain: [nightly]
         include:
           - os: ubuntu
-            toolchain: 1.77.0
+            toolchain: 1.85.0
           - os: ubuntu
             toolchain: nightly
             libbsd: true
@@ -40,10 +40,20 @@ jobs:
         with:
           name: pass-${{ matrix.os }}-${{ matrix.toolchain }}
           path: target/debug/examples/pass${{ env.suffix }}
+
+        # "minimal" builds: either libbsd or linux-vendored on linux,
+        # windows-vendored on windows, no features on other platforms
+      - run: cargo test --all-targets --no-default-features --features=libbsd
+        if: ${{ matrix.libbsd }}
+      - run: cargo test --all-targets --no-default-features --features=linux-vendored
+        if: ${{ !matrix.libbsd && matrix.os == 'ubuntu' }}
+      - run: cargo test --all-targets --no-default-features --features=windows-vendored
+        if: ${{ matrix.os == 'windows' }}
+      - run: cargo test --all-targets --no-default-features
+        if: ${{ matrix.os != 'windows' && matrix.os != 'ubuntu' }}
+
       - run: cargo test --all-targets
-      - run: cargo test --all-targets --features=zeroize
-      - run: cargo test --all-targets --features=libbsd-static --features=windows-vendored --no-default-features
-        if: ${{ matrix.os != 'ubuntu' || matrix.libbsd }}
+      - run: cargo test --all-targets --all-features
 
   lint:
     name: cargo fmt && cargo clippy

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,8 +41,8 @@ jobs:
           name: pass-${{ matrix.os }}-${{ matrix.toolchain }}
           path: target/debug/examples/pass${{ env.suffix }}
 
-        # "minimal" builds: either libbsd or linux-vendored on linux,
-        # windows-vendored on windows, no features on other platforms
+      # "minimal" builds: either libbsd or linux-vendored on linux,
+      # windows-vendored on windows, no features on other platforms
       - run: cargo test --all-targets --no-default-features --features=libbsd
         if: ${{ matrix.libbsd }}
       - run: cargo test --all-targets --no-default-features --features=linux-vendored

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,12 +3,12 @@ name = "readpassphrase-3"
 version = "1.0.2"
 categories = ["command-line-interface"]
 documentation = "https://docs.rs/readpassphrase-3"
-edition = "2021"
+edition = "2024"
 keywords = ["read", "password", "getpass", "passphrase", "tty"]
 license = "MIT OR Apache-2.0 OR ISC"
 readme = "README.md"
 repository = "https://github.com/mrdomino/readpassphrase-3"
-rust-version = "1.77.0"
+rust-version = "1.85.0"
 description = "Simple wrapper around readpassphrase(3)"
 
 exclude = [
@@ -33,7 +33,8 @@ path = "examples/owned.rs"
 [features]
 default = ["linux-vendored", "windows-vendored"]
 external = []
-libbsd-static = []
+libbsd = ["dep:libbsd-sys"]
+libbsd-static = ["libbsd", "libbsd-sys/static"]
 linux-vendored = ["dep:tcm-readpassphrase-vendored"]
 windows-vendored = ["dep:cc"]
 zeroize = ["dep:zeroize"]
@@ -42,7 +43,10 @@ zeroize = ["dep:zeroize"]
 bitflags = "2"
 zeroize = { version = "1", optional = true }
 
-[target.'cfg(not(any(target_os = "macos", target_os = "windows")))'.dependencies]
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+libbsd-sys = { version = "0.1.3", optional = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
 tcm-readpassphrase-vendored = { version = "0.2", optional = true }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -41,10 +41,10 @@ fn main() {
     }
 
     if target_os == "macos"
+        || target_os == "dragonflybsd"
         || target_os == "freebsd"
         || target_os == "netbsd"
         || target_os == "openbsd"
-        || target_os == "dragonflybsd"
     {
         println!("cargo:rustc-cfg=use_external");
         return;

--- a/build.rs
+++ b/build.rs
@@ -1,74 +1,59 @@
+use std::ffi::OsString;
+
 fn main() {
-    // Check for a readpassphrase implementation in the following places in decreasing order of
-    // preference:
-    // 1. macOS libc.
-    // 2. The libbsd static library.
-    // 3. The Windows vendored source code on Windows.
-    // 4. The non-Windows vendored source code from the dependent crate.
-    //
-    // If the implementation comes from the dependent crate, then we also need to set a cfg
-    // directive to tell the library to use it.
+    println!("cargo:rustc-check-cfg=cfg(use_libbsd)");
     println!("cargo:rustc-check-cfg=cfg(use_tcm)");
-    let mut found_readpassphrase = false;
+    println!("cargo:rustc-check-cfg=cfg(use_external)");
 
-    println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_OS");
-    let target_os = std::env::var_os("CARGO_CFG_TARGET_OS").unwrap_or_default();
-    if target_os == "macos" {
-        // macOS ships readpassphrase in its libc.
-        found_readpassphrase = true;
+    if env_var_os("CARGO_FEATURE_EXTERNAL").is_some() {
+        println!("cargo:rustc-cfg=use_external");
+        return;
     }
 
-    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_LIBBSD_STATIC");
-    if !found_readpassphrase && std::env::var_os("CARGO_FEATURE_LIBBSD_STATIC").is_some() {
-        // Rerun if any environment variable affecting pkg-config changes
-        println!("cargo:rerun-if-env-changed=PKG_CONFIG_PATH");
-        println!("cargo:rerun-if-env-changed=PKG_CONFIG_DEBUG_SPEW");
-        println!("cargo:rerun-if-env-changed=PKG_CONFIG_TOP_BUILD_DIR");
-        println!("cargo:rerun-if-env-changed=PKG_CONFIG_DISABLE_UNINSTALLED");
-        println!("cargo:rerun-if-env-changed=PKG_CONFIG_ALLOW_SYSTEM_CFLAGS");
-        println!("cargo:rerun-if-env-changed=PKG_CONFIG_ALLOW_SYSTEM_LIBS");
-        println!("cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR");
-        println!("cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR");
+    let target_os = env_var_os("CARGO_CFG_TARGET_OS").unwrap_or_default();
 
-        match std::process::Command::new("pkg-config")
-            .args(["--atleast-version", "0.9", "--exists", "--static", "libbsd"])
-            .status()
-        {
-            Ok(status) if status.success() => {
-                println!("cargo:rustc-link-lib=static:-bundle=bsd");
-                found_readpassphrase = true;
+    if target_os == "windows" {
+        if env_var_os("CARGO_CFG_FEATURE_WINDOWS_VENDORED").is_some() {
+            // Needs to be a cfg directive since cc is an optional build dependency with these conditions.
+            #[cfg(all(target_os = "windows", feature = "windows-vendored"))]
+            {
+                cc::Build::new()
+                    .file("csrc/read-password-w32.c")
+                    .compile("read-password-w32");
             }
-            Ok(_) => eprintln!("Warning: libbsd not found or version too old"),
-            Err(e) => eprintln!("Warning: pkg-config failed: {e}"),
-        }
-    }
-
-    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_WINDOWS_VENDORED");
-    // Needs to be a cfg directive since cc is an optional build dependency with these conditions.
-    #[cfg(all(target_os = "windows", feature = "windows-vendored"))]
-    {
-        if !found_readpassphrase {
-            cc::Build::new()
-                .file("csrc/read-password-w32.c")
-                .compile("read-password-w32");
             println!("cargo:rerun-if-changed=csrc/read-password-w32.c");
-            found_readpassphrase = true;
+            return;
         }
+        panic!("unsupported platform/feature combo - try external or windows-vendored");
     }
 
-    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_LINUX_VENDORED");
-    if !found_readpassphrase
-        && target_os != "windows"
-        && std::env::var_os("CARGO_FEATURE_LINUX_VENDORED").is_some()
+    if env_var_os("CARGO_FEATURE_LIBBSD").is_some() {
+        println!("cargo:rustc-cfg=use_libbsd");
+        return;
+    }
+
+    if target_os == "linux" {
+        if env_var_os("CARGO_FEATURE_LINUX_VENDORED").is_some() {
+            println!("cargo:rustc-cfg=use_tcm");
+            return;
+        }
+        panic!("unsupported platform/feature combo - try external or libbsd or linux-vendored");
+    }
+
+    if target_os == "macos"
+        || target_os == "freebsd"
+        || target_os == "netbsd"
+        || target_os == "openbsd"
+        || target_os == "dragonflybsd"
     {
-        found_readpassphrase = true;
-        // Fetch readpassphrase out of the dependent crate.
-        println!("cargo:rustc-cfg=use_tcm");
+        println!("cargo:rustc-cfg=use_external");
+        return;
     }
 
-    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_EXTERNAL");
-    if !found_readpassphrase && std::env::var_os("CARGO_FEATURE_EXTERNAL").is_none() {
-        eprintln!("No readpassphrase implementation found.");
-        std::process::exit(1);
-    }
+    panic!("unsupported platform");
+}
+
+fn env_var_os(key: &str) -> Option<OsString> {
+    println!("cargo:rerun-if-env-changed={key}");
+    std::env::var_os(key)
 }

--- a/build.rs
+++ b/build.rs
@@ -1,14 +1,8 @@
 use std::ffi::OsString;
 
 fn main() {
-    println!("cargo:rustc-check-cfg=cfg(use_libbsd)");
     println!("cargo:rustc-check-cfg=cfg(use_tcm)");
-    println!("cargo:rustc-check-cfg=cfg(use_external)");
-
-    if env_var_os("CARGO_FEATURE_EXTERNAL").is_some() {
-        println!("cargo:rustc-cfg=use_external");
-        return;
-    }
+    println!("cargo:rustc-check-cfg=cfg(use_libbsd)");
 
     let target_os = env_var_os("CARGO_CFG_TARGET_OS").unwrap_or_default();
 
@@ -24,20 +18,27 @@ fn main() {
             println!("cargo:rerun-if-changed=csrc/read-password-w32.c");
             return;
         }
+        if use_external() {
+            return;
+        }
         panic!("unsupported platform/feature combo - try external or windows-vendored");
     }
 
-    if env_var_os("CARGO_FEATURE_LIBBSD").is_some() {
-        println!("cargo:rustc-cfg=use_libbsd");
-        return;
-    }
-
     if target_os == "linux" {
-        if env_var_os("CARGO_FEATURE_LINUX_VENDORED").is_some() {
-            println!("cargo:rustc-cfg=use_tcm");
+        if use_linux_vendored() {
+            return;
+        }
+        if use_libbsd() {
+            return;
+        }
+        if use_external() {
             return;
         }
         panic!("unsupported platform/feature combo - try external or libbsd or linux-vendored");
+    }
+
+    if use_libbsd() {
+        return;
     }
 
     if target_os == "macos"
@@ -45,15 +46,35 @@ fn main() {
         || target_os == "freebsd"
         || target_os == "netbsd"
         || target_os == "openbsd"
+        || use_external()
     {
-        println!("cargo:rustc-cfg=use_external");
         return;
     }
 
-    panic!("unsupported platform");
+    panic!("unsupported platform/feature combo - try external or libbsd");
 }
 
 fn env_var_os(key: &str) -> Option<OsString> {
     println!("cargo:rerun-if-env-changed={key}");
     std::env::var_os(key)
+}
+
+fn use_external() -> bool {
+    env_var_os("CARGO_FEATURE_EXTERNAL").is_some()
+}
+
+fn use_libbsd() -> bool {
+    if env_var_os("CARGO_FEATURE_LIBBSD").is_some() {
+        println!("cargo:rustc-cfg=use_libbsd");
+        return true;
+    }
+    false
+}
+
+fn use_linux_vendored() -> bool {
+    if env_var_os("CARGO_FEATURE_LINUX_VENDORED").is_some() {
+        println!("cargo:rustc-cfg=use_tcm");
+        return true;
+    }
+    false
 }

--- a/build.rs
+++ b/build.rs
@@ -13,7 +13,7 @@ fn main() {
     let target_os = env_var_os("CARGO_CFG_TARGET_OS").unwrap_or_default();
 
     if target_os == "windows" {
-        if env_var_os("CARGO_CFG_FEATURE_WINDOWS_VENDORED").is_some() {
+        if env_var_os("CARGO_FEATURE_WINDOWS_VENDORED").is_some() {
             // Needs to be a cfg directive since cc is an optional build dependency with these conditions.
             #[cfg(all(target_os = "windows", feature = "windows-vendored"))]
             {

--- a/build.rs
+++ b/build.rs
@@ -25,10 +25,10 @@ fn main() {
     }
 
     if target_os == "linux" {
-        if use_linux_vendored() {
+        if use_libbsd() {
             return;
         }
-        if use_libbsd() {
+        if use_linux_vendored() {
             return;
         }
         if use_external() {

--- a/examples/inplace.rs
+++ b/examples/inplace.rs
@@ -1,6 +1,6 @@
 use std::process::exit;
 
-use readpassphrase_3::{readpassphrase, Flags as RpFlags, PASSWORD_LEN};
+use readpassphrase_3::{Flags as RpFlags, PASSWORD_LEN, readpassphrase};
 use zeroize::Zeroizing;
 
 fn main() {

--- a/examples/owned.rs
+++ b/examples/owned.rs
@@ -1,4 +1,4 @@
-use readpassphrase_3::{readpassphrase, readpassphrase_into, Error, Flags, PASSWORD_LEN};
+use readpassphrase_3::{Error, Flags, PASSWORD_LEN, readpassphrase, readpassphrase_into};
 use zeroize::{Zeroize, Zeroizing};
 
 fn main() -> Result<(), Error> {

--- a/examples/pass.rs
+++ b/examples/pass.rs
@@ -1,4 +1,4 @@
-use readpassphrase_3::{getpass, Zeroize};
+use readpassphrase_3::{Zeroize, getpass};
 
 fn main() {
     let mut password = getpass(c"Password: ").expect("failed reading password");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -451,11 +451,17 @@ mod our_zeroize {
 
 #[cfg(use_tcm)]
 use tcm_readpassphrase_vendored as ffi;
+
 #[cfg(not(use_tcm))]
 mod ffi {
+    #[cfg(use_libbsd)]
+    pub(crate) use libbsd_sys::readpassphrase;
+
+    #[cfg(not(use_libbsd))]
     use std::ffi::{c_char, c_int};
 
-    extern "C" {
+    #[cfg(not(use_libbsd))]
+    unsafe extern "C" {
         pub(crate) fn readpassphrase(
             prompt: *const c_char,
             buf: *mut c_char,


### PR DESCRIPTION
This pulls `readpassphrase` from [libbsd-sys] if it is available. It reworks the build script, hopefully making the per-platform decision tree clearer. Since the `libbsd` feature is now about whether the crate has been included in the build already, the build is already broken if `libbsd-dev` is unavailable, so `libbsd` now takes top priority on platforms where it is available. If the build script fails to find a solution, it panics with a message saying what features are available for the current platform.

This changes the `use_tcm` config to be Linux-only; previously the vendored source was tried on any non-Windows platform. This might break some obscure platforms; rather than assuming that the vendored Linux source would have worked on those platforms, we leave them broken to handle on a case-by-case basis.

[libbsd-sys]: https://crates.io/crates/libbsd-sys