### PR TITLE
feat!: Use libbsd-sys for ffi where possible

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,6 @@ jobs:
     name: cargo fmt && cargo clippy
     runs-on: ubuntu-latest
     steps:
-      - run: echo LIBBSD_NO_PKG_CONFIG=1 >> $GITHUB_ENV
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,7 @@ jobs:
     name: cargo fmt && cargo clippy
     runs-on: ubuntu-latest
     steps:
+      - run: echo LIBBSD_NO_PKG_CONFIG= >> $GITHUB_ENV
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,7 @@ jobs:
     name: cargo fmt && cargo clippy
     runs-on: ubuntu-latest
     steps:
+      - run: echo LIBBSD_NO_PKG_CONFIG=1 >> $GITHUB_ENV
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,6 @@ jobs:
     name: cargo fmt && cargo clippy
     runs-on: ubuntu-latest
     steps:
-      - run: echo LIBBSD_NO_PKG_CONFIG= >> $GITHUB_ENV
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,10 +14,9 @@ jobs:
         toolchain: [nightly]
         include:
           - os: ubuntu
-            toolchain: 1.77.0
+            toolchain: 1.85.0
           - os: ubuntu
             toolchain: nightly
-            libbsd: true
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: setup environment
@@ -29,7 +28,7 @@ jobs:
             echo suffix=
           fi >> $GITHUB_ENV
       - name: install libbsd
-        if: ${{ matrix.libbsd }}
+        if: ${{ matrix.os == 'ubuntu' }}
         run: sudo sh -c 'apt-get update && apt-get -y install libbsd-dev'
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -40,15 +39,19 @@ jobs:
         with:
           name: pass-${{ matrix.os }}-${{ matrix.toolchain }}
           path: target/debug/examples/pass${{ env.suffix }}
+      - run: cargo test --all-targets --no-default-features
       - run: cargo test --all-targets
-      - run: cargo test --all-targets --features=zeroize
-      - run: cargo test --all-targets --features=libbsd-static --features=windows-vendored --no-default-features
-        if: ${{ matrix.os != 'ubuntu' || matrix.libbsd }}
+      - run: cargo test --all-targets --all-features
+      - run: cargo publish --dry-run
+        if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/main')
 
   lint:
     name: cargo fmt && cargo clippy
     runs-on: ubuntu-latest
     steps:
+      # TODO(soon): remove, fix in libbsd-sys
+      - name: install libbsd
+        run: sudo sh -c 'apt-get update && apt-get -y install libbsd-dev'
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -67,7 +70,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: cargo generate-lockfile && cat Cargo.lock
-      - run: cargo publish --dry-run
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,9 +49,6 @@ jobs:
     name: cargo fmt && cargo clippy
     runs-on: ubuntu-latest
     steps:
-      # TODO(soon): remove, fix in libbsd-sys
-      - name: install libbsd
-        run: sudo sh -c 'apt-get update && apt-get -y install libbsd-dev'
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ bitflags = "2"
 zeroize = { version = "1", optional = true }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-libbsd-sys = "0.1"
+libbsd-sys = "0.2"
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 cc = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "readpassphrase-3"
-version = "1.0.2"
+version = "2.0.0-pre.0"
 categories = ["command-line-interface"]
 documentation = "https://docs.rs/readpassphrase-3"
-edition = "2021"
+edition = "2024"
 keywords = ["read", "password", "getpass", "passphrase", "tty"]
 license = "MIT OR Apache-2.0 OR ISC"
 readme = "README.md"
 repository = "https://github.com/mrdomino/readpassphrase-3"
-rust-version = "1.77.0"
+rust-version = "1.85.0"
 description = "Simple wrapper around readpassphrase(3)"
 
 exclude = [
@@ -31,27 +31,23 @@ name = "owned"
 path = "examples/owned.rs"
 
 [features]
-default = ["linux-vendored", "windows-vendored"]
-external = []
-libbsd-static = []
-linux-vendored = ["dep:tcm-readpassphrase-vendored"]
-windows-vendored = ["dep:cc"]
+default = ["libbsd-static"]
+libbsd-static = ["libbsd-sys/static"]
 zeroize = ["dep:zeroize"]
 
 [dependencies]
 bitflags = "2"
 zeroize = { version = "1", optional = true }
 
-[target.'cfg(not(any(target_os = "macos", target_os = "windows")))'.dependencies]
-tcm-readpassphrase-vendored = { version = "0.2", optional = true }
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+libbsd-sys = "0.1"
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
-cc = { version = "1", optional = true }
+cc = "1"
 
 [dev-dependencies]
 zeroize = "1"
 
 [package.metadata.docs.rs]
-features = ["external", "zeroize"]
-# XXX cc is crashing on mac and windows on docs.rs
-no-default-features = true
+features = ["zeroize"]
+default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ bitflags = "2"
 zeroize = { version = "1", optional = true }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-libbsd-sys = "0.2"
+libbsd-sys = "=0.2.0"
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 cc = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ bitflags = "2"
 zeroize = { version = "1", optional = true }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-libbsd-sys = "=0.2.0"
+libbsd-sys = "0.2"
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 cc = "1"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # readpassphrase-3
 This crate endeavors to expose a thin Rust wrapper around the C [`readpassphrase(3)`][0] function for reading passphrases on the console in CLI programs.
 
-It uses a few third-party dependencies: flags to `readpassphrase` are implemented via the [`bitflags`][1] library, native builds are done via [`cc`][2], and memory zeroing can optionally be done by [`zeroize`][3]. To try to reduce churn in this library itself, we do not lock the versions of these dependencies; it is recommended that you vet their current versions yourself for compromises or software supply chain attacks. If you would rather not do that (or if you need support for wasm), consider instead using the excellent [`rpassword`][4] crate, which ships without external dependencies.
+It uses a few third-party dependencies: flags to `readpassphrase` are implemented via the [`bitflags`][1] library, native builds are done via [`cc`][2], and memory zeroing can optionally be done by [`zeroize`][3]. Additionally, on Linux, the `libbsd` development package must be installed (e.g. `libbsd-dev` on Debian/Ubuntu), and is pulled in via [`libbsd-sys`][4].
+
+To try to reduce churn in this library itself, we do not lock the versions of these dependencies; it is recommended that you vet their current versions yourself for compromises or software supply chain attacks. If you would rather not do that (or if you need support for wasm), consider instead using the excellent [`rpassword`][4] crate, which ships without external dependencies.
 
 # Usage
 Add this crate to your project:
@@ -16,10 +18,7 @@ cargo add readpassphrase-3 -F zeroize
 See <https://docs.rs/readpassphrase-3> for documentation and examples.
 
 # Crate Features
-- `linux-vendored`, enabled by default, uses (on non-Windows and non-macOS) the bundled BSD readpassphrase source from the first-party [`tcm-readpassphrase-vendored`][5] crate, shipped separately so as to not subject this crate to the (permissive) ISC license.
-- `windows-vendored`, also enabled by default, uses (on Windows only) a bundled readpassphrase implementation from the public domain.
-- `external` tells Rust to expect a `readpassphrase` implementation to be provided externally (e.g. by an external build system like Bazel); this crate will not complain if it does not find one in the build script.
-- `libbsd-static` uses `readpassphrase` from the `libbsd` system library statically, i.e. without incurring a runtime dependency.
+- `libbsd-static`, enabled by default, turns on the `static` feature of [`libbsd-sys`][5]. (Without this, end users will need the non-development `libbsd` system package installed to run executables that depend on this crate.)
 - `zeroize` uses [`zeroize`][3] to zero memory internally (otherwise a minimal in-crate version is used.)
 
 # NFAQ
@@ -53,7 +52,7 @@ There is already an unmaintained [`readpassphrase`][8] crate that was not to my 
 [2]: https://crates.io/crates/cc
 [3]: https://crates.io/crates/zeroize
 [4]: https://crates.io/crates/rpassword
-[5]: https://crates.io/crates/tcm-readpassphrase-vendored
+[5]: https://crates.io/crates/libbsd-sys
 [6]: https://doc.rust-lang.org/std/ffi/struct.CStr.html
 [7]: https://doc.rust-lang.org/std/ffi/struct.CString.html
 [8]: https://crates.io/crates/readpassphrase

--- a/build.rs
+++ b/build.rs
@@ -1,74 +1,13 @@
 fn main() {
-    // Check for a readpassphrase implementation in the following places in decreasing order of
-    // preference:
-    // 1. macOS libc.
-    // 2. The libbsd static library.
-    // 3. The Windows vendored source code on Windows.
-    // 4. The non-Windows vendored source code from the dependent crate.
-    //
-    // If the implementation comes from the dependent crate, then we also need to set a cfg
-    // directive to tell the library to use it.
-    println!("cargo:rustc-check-cfg=cfg(use_tcm)");
-    let mut found_readpassphrase = false;
-
     println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_OS");
-    let target_os = std::env::var_os("CARGO_CFG_TARGET_OS").unwrap_or_default();
-    if target_os == "macos" {
-        // macOS ships readpassphrase in its libc.
-        found_readpassphrase = true;
-    }
-
-    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_LIBBSD_STATIC");
-    if !found_readpassphrase && std::env::var_os("CARGO_FEATURE_LIBBSD_STATIC").is_some() {
-        // Rerun if any environment variable affecting pkg-config changes
-        println!("cargo:rerun-if-env-changed=PKG_CONFIG_PATH");
-        println!("cargo:rerun-if-env-changed=PKG_CONFIG_DEBUG_SPEW");
-        println!("cargo:rerun-if-env-changed=PKG_CONFIG_TOP_BUILD_DIR");
-        println!("cargo:rerun-if-env-changed=PKG_CONFIG_DISABLE_UNINSTALLED");
-        println!("cargo:rerun-if-env-changed=PKG_CONFIG_ALLOW_SYSTEM_CFLAGS");
-        println!("cargo:rerun-if-env-changed=PKG_CONFIG_ALLOW_SYSTEM_LIBS");
-        println!("cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR");
-        println!("cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR");
-
-        match std::process::Command::new("pkg-config")
-            .args(["--atleast-version", "0.9", "--exists", "--static", "libbsd"])
-            .status()
+    if std::env::var_os("CARGO_CFG_TARGET_OS").is_some_and(|os| os == "windows") {
+        // Needs to be cfg directive since cc is an optional build dependency with this condition.
+        #[cfg(target_os = "windows")]
         {
-            Ok(status) if status.success() => {
-                println!("cargo:rustc-link-lib=static:-bundle=bsd");
-                found_readpassphrase = true;
-            }
-            Ok(_) => eprintln!("Warning: libbsd not found or version too old"),
-            Err(e) => eprintln!("Warning: pkg-config failed: {e}"),
-        }
-    }
-
-    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_WINDOWS_VENDORED");
-    // Needs to be a cfg directive since cc is an optional build dependency with these conditions.
-    #[cfg(all(target_os = "windows", feature = "windows-vendored"))]
-    {
-        if !found_readpassphrase {
             cc::Build::new()
                 .file("csrc/read-password-w32.c")
                 .compile("read-password-w32");
             println!("cargo:rerun-if-changed=csrc/read-password-w32.c");
-            found_readpassphrase = true;
         }
-    }
-
-    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_LINUX_VENDORED");
-    if !found_readpassphrase
-        && target_os != "windows"
-        && std::env::var_os("CARGO_FEATURE_LINUX_VENDORED").is_some()
-    {
-        found_readpassphrase = true;
-        // Fetch readpassphrase out of the dependent crate.
-        println!("cargo:rustc-cfg=use_tcm");
-    }
-
-    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_EXTERNAL");
-    if !found_readpassphrase && std::env::var_os("CARGO_FEATURE_EXTERNAL").is_none() {
-        eprintln!("No readpassphrase implementation found.");
-        std::process::exit(1);
     }
 }

--- a/examples/inplace.rs
+++ b/examples/inplace.rs
@@ -1,6 +1,6 @@
 use std::process::exit;
 
-use readpassphrase_3::{readpassphrase, Flags as RpFlags, PASSWORD_LEN};
+use readpassphrase_3::{Flags as RpFlags, PASSWORD_LEN, readpassphrase};
 use zeroize::Zeroizing;
 
 fn main() {

--- a/examples/owned.rs
+++ b/examples/owned.rs
@@ -1,4 +1,4 @@
-use readpassphrase_3::{readpassphrase, readpassphrase_into, Error, Flags, PASSWORD_LEN};
+use readpassphrase_3::{Error, Flags, PASSWORD_LEN, readpassphrase, readpassphrase_into};
 use zeroize::{Zeroize, Zeroizing};
 
 fn main() -> Result<(), Error> {

--- a/examples/pass.rs
+++ b/examples/pass.rs
@@ -1,4 +1,4 @@
-use readpassphrase_3::{getpass, Zeroize};
+use readpassphrase_3::{Zeroize, getpass};
 
 fn main() {
     let mut password = getpass(c"Password: ").expect("failed reading password");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,13 +449,15 @@ mod our_zeroize {
     }
 }
 
-#[cfg(use_tcm)]
-use tcm_readpassphrase_vendored as ffi;
-#[cfg(not(use_tcm))]
+#[cfg(not(target_os = "windows"))]
+mod ffi {
+    pub(crate) use libbsd_sys::readpassphrase;
+}
+#[cfg(target_os = "windows")]
 mod ffi {
     use std::ffi::{c_char, c_int};
 
-    extern "C" {
+    unsafe extern "C" {
         pub(crate) fn readpassphrase(
             prompt: *const c_char,
             buf: *mut c_char,


### PR DESCRIPTION
Dramatically simplifies the build in this crate; now we only use the vendored Windows code on Windows, and only use libbsd-sys elsewhere. Gone is the Linux vendored source code; now we always take `readpassphrase` from libbsd, whether dynamically or statically.

The tradeoff is that now on Linux, one must have the `libbsd` dev library installed at build time. This is no longer optional. As such, it’s a breaking change.

As well, we now depend on an AI-generated FFI wrapper. Not sure how I feel about this.